### PR TITLE
refactor: improve proxy api detection

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,3 +1,5 @@
+import { hasProxy } from './utils/env';
+
 export default GlobalEmitter => ({
   created() {
     const { sockets = {} } = this.$options;
@@ -6,7 +8,7 @@ export default GlobalEmitter => ({
       GlobalEmitter.addListener(key, sockets[key], this);
     });
 
-    if (!window.Proxy) return;
+    if (!hasProxy) return;
     this.$options.sockets = new Proxy(sockets, {
       set: (target, key, value) => {
         GlobalEmitter.addListener(key, value, this);
@@ -26,7 +28,7 @@ export default GlobalEmitter => ({
     const { sockets = {} } = this.$options;
 
     Object.keys(sockets).forEach((key) => {
-      if (!window.Proxy) {
+      if (!hasProxy) {
         GlobalEmitter.removeListener(key, sockets[key], this);
       }
       delete this.$options.sockets[key];

--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -1,0 +1,8 @@
+/* eslint-disable import/prefer-default-export */
+
+function isNative(Ctor) {
+  return typeof Ctor === 'function' && /native code/.test(Ctor.toString());
+}
+
+export const hasProxy =
+  typeof Proxy !== 'undefined' && isNative(Proxy);


### PR DESCRIPTION
- no more relies on `window.Proxy` as `window` may not exist in SSR environment
- correctly detects is Proxy natively supported by browser (no more issue with polyfill)
- potentially improves testing experience for `mixin` as we can mock `/utils/env` instead of touching global environment