### PR TITLE
Refactor/improve passToStore in observer

### DIFF
--- a/src/Observer.js
+++ b/src/Observer.js
@@ -49,7 +49,6 @@ export default class Observer {
 
     actions.forEach((namespacedAction) => {
       const action = trimNamespace(namespacedAction);
-      if (!action.startsWith('socket_')) return;
       const camelcased = eventToAction(event);
       if (action !== camelcased) return;
       this.store.dispatch(namespacedAction, unwrappedPayload);

--- a/src/Observer.js
+++ b/src/Observer.js
@@ -1,8 +1,12 @@
 import GlobalEmitter from './GlobalEmitter';
-import { eventToAction, unwrapIfSingle } from './utils';
+import { unwrapIfSingle, prefixWith, pipe } from './utils';
 import { getRegisteredMutations, getRegisteredActions, trimNamespace } from './utils/vuex';
+import { eventToMutationTransformer, eventToActionTransformer } from './utils/observer';
 
 const SYSTEM_EVENTS = ['connect', 'error', 'disconnect', 'reconnect', 'reconnect_attempt', 'reconnecting', 'reconnect_error', 'reconnect_failed', 'connect_error', 'connect_timeout', 'connecting', 'ping', 'pong'];
+
+const actionPrefix = 'socket_';
+const mutationPrefix = 'SOCKET_';
 
 export default class Observer {
   constructor(connection, store) {
@@ -21,13 +25,13 @@ export default class Observer {
       GlobalEmitter.emit(...packet.data);
 
       const [eventName, ...args] = packet.data;
-      this.passToStore(`SOCKET_${eventName}`, [...args]);
+      this.passToStore(eventName, [...args]);
     };
 
     SYSTEM_EVENTS.forEach((eventName) => {
       this.Socket.on(eventName, (...args) => {
         GlobalEmitter.emit(eventName, ...args);
-        this.passToStore(`SOCKET_${eventName}`, [...args]);
+        this.passToStore(eventName, [...args]);
       });
     });
   }
@@ -35,23 +39,23 @@ export default class Observer {
 
   passToStore(event, payload) {
     if (!this.store) return;
-    if (!event.startsWith('SOCKET_')) return;
 
     const unwrappedPayload = unwrapIfSingle(payload);
+    const eventToAction = pipe(eventToActionTransformer, prefixWith(actionPrefix));
+    const eventToMutation = pipe(eventToMutationTransformer, prefixWith(mutationPrefix));
+
+    const desiredMutation = eventToMutation(event);
+    const desiredAction = eventToAction(event);
+
     const mutations = getRegisteredMutations(this.store);
     const actions = getRegisteredActions(this.store);
 
-    mutations.forEach((namespacedMutation) => {
-      const mutation = trimNamespace(namespacedMutation);
-      if (mutation !== event.toUpperCase()) return;
-      this.store.commit(namespacedMutation, unwrappedPayload);
-    });
+    mutations
+      .filter(namespacedMutation => trimNamespace(namespacedMutation) === desiredMutation)
+      .forEach(namespacedMutation => this.store.commit(namespacedMutation, unwrappedPayload));
 
-    actions.forEach((namespacedAction) => {
-      const action = trimNamespace(namespacedAction);
-      const camelcased = eventToAction(event);
-      if (action !== camelcased) return;
-      this.store.dispatch(namespacedAction, unwrappedPayload);
-    });
+    actions
+      .filter(namespacedAction => trimNamespace(namespacedAction) === desiredAction)
+      .forEach(namespacedAction => this.store.dispatch(namespacedAction, unwrappedPayload));
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import './polyfills';
 import Main from './Main';
 
 export default Main;

--- a/src/polyfills/String.prototype.startsWith.js
+++ b/src/polyfills/String.prototype.startsWith.js
@@ -1,6 +1,0 @@
-/* eslint-disable no-extend-native */
-if (!String.prototype.startsWith) {
-  String.prototype.startsWith = function startsWith(search, pos) {
-    return this.substr(!pos || pos < 0 ? 0 : +pos, search.length) === search;
-  };
-}

--- a/src/polyfills/index.js
+++ b/src/polyfills/index.js
@@ -1,1 +1,0 @@
-import './String.prototype.startsWith';

--- a/src/utils/__tests__/index.spec.js
+++ b/src/utils/__tests__/index.spec.js
@@ -1,22 +1,4 @@
-import { eventToAction, isFunction, isSocketIo, unwrapIfSingle } from '../';
-
-describe('.eventToAction()', () => {
-  it('should be a function', () => {
-    expect(eventToAction).toEqual(expect.any(Function));
-  });
-
-  it('should correctly convert socket event name to camelcased action name', () => {
-    expect(eventToAction('SOCKET_USER_MESSAGE')).toBe('socket_userMessage');
-    expect(eventToAction('SOCKET_userMessage')).toBe('socket_userMessage');
-    expect(eventToAction('SOCKET_UserMessage')).toBe('socket_userMessage');
-    expect(eventToAction('SOCKET_user-message')).toBe('socket_userMessage');
-  });
-
-  it('should add `socket_` prefix to action', () => {
-    expect(eventToAction('message')).toBe('socket_message');
-    expect(eventToAction('USER_MESSAGE')).toBe('socket_userMessage');
-  });
-});
+import { isFunction, isSocketIo, unwrapIfSingle } from '../';
 
 describe('.isFunction()', () => {
   it('should return false for value other than function', () => {

--- a/src/utils/__tests__/vuex.spec.js
+++ b/src/utils/__tests__/vuex.spec.js
@@ -1,0 +1,144 @@
+import { createLocalVue } from '@vue/test-utils';
+import Vuex, { Store } from 'vuex';
+import { getRegisteredActions, getRegisteredMutations, trimNamespace } from '../vuex';
+
+const Vue = createLocalVue();
+Vue.use(Vuex);
+
+const noop = () => undefined;
+
+describe('.getRegisteredActions()', () => {
+  it('is a function', () => {
+    expect(getRegisteredActions).toEqual(expect.any(Function));
+  });
+  it('returns empty array if no actions registered', () => {
+    const store = new Store({});
+    expect(getRegisteredActions(store)).toEqual([]);
+  });
+  it('returns array of actions', () => {
+    const store = new Store({
+      actions: {
+        thisAction: noop,
+        oneMore: noop,
+      },
+    });
+    expect(getRegisteredActions(store)).toEqual(['thisAction', 'oneMore']);
+  });
+  it('returns array of actions including namespaced modules', () => {
+    const test = {
+      namespaced: true,
+      actions: {
+        oneMore: noop,
+        connect: noop,
+      },
+    };
+    const router = {
+      namespaced: true,
+      actions: {
+        navigate: noop,
+      },
+    };
+    const store = new Store({
+      actions: {
+        thisAction: noop,
+      },
+      modules: { test, router },
+    });
+    expect(getRegisteredActions(store)).toEqual([
+      'thisAction',
+      'test/oneMore',
+      'test/connect',
+      'router/navigate',
+    ]);
+  });
+  it('do not return mutations', () => {
+    const store = new Store({
+      mutations: {
+        testMutation: noop,
+      },
+      actions: {
+        testAction: noop,
+      },
+    });
+    expect(getRegisteredActions(store)).not.toContain('testMutation');
+  });
+});
+
+describe('.getRegisteredMutations()', () => {
+  it('is a function', () => {
+    expect(getRegisteredMutations).toEqual(expect.any(Function));
+  });
+  it('returns empty array if no mutations registered', () => {
+    const store = new Store({});
+    expect(getRegisteredActions(store)).toEqual([]);
+  });
+  it('returns array of mutations', () => {
+    const store = new Store({
+      mutations: {
+        thisMutation: noop,
+        oneMore: noop,
+      },
+    });
+    expect(getRegisteredMutations(store)).toEqual(['thisMutation', 'oneMore']);
+  });
+  it('returns array of mutations including namespaced modules', () => {
+    const test = {
+      namespaced: true,
+      mutations: {
+        oneMore: noop,
+        connect: noop,
+      },
+    };
+    const router = {
+      namespaced: true,
+      mutations: {
+        navigate: noop,
+      },
+    };
+    const store = new Store({
+      mutations: {
+        thisMutation: noop,
+      },
+      modules: { test, router },
+    });
+    expect(getRegisteredMutations(store)).toEqual([
+      'thisMutation',
+      'test/oneMore',
+      'test/connect',
+      'router/navigate',
+    ]);
+  });
+  it('do not return actions', () => {
+    const store = new Store({
+      mutations: {
+        testMutation: noop,
+      },
+      actions: {
+        testAction: noop,
+      },
+    });
+    expect(getRegisteredMutations(store)).not.toContain('testAction');
+  });
+});
+
+describe('.trimNamespace()', () => {
+  it('is a function', () => {
+    expect(trimNamespace).toEqual(expect.any(Function));
+  });
+  it('returns common string "as-is"', () => {
+    ['', 'test', 'super action', 'SOCKET_CONNECT', 'test\\action', 'change|user']
+      .forEach(str => (
+        expect(trimNamespace(str)).toBe(str)
+      ));
+  });
+  it('trims namespaces from given string', () => {
+    expect(trimNamespace('socket/connect')).toBe('connect');
+    expect(trimNamespace('MODULE/TEST')).toBe('TEST');
+    expect(trimNamespace('MODULE/TEST\\TEST')).toBe('TEST\\TEST');
+  });
+  it('trims deeps namespace namespaces from given string', () => {
+    expect(trimNamespace('super/deep/socket/connect')).toBe('connect');
+    expect(trimNamespace('a/b/c/d/E/f/G/K/L/M/N')).toBe('N');
+    expect(trimNamespace('/////D')).toBe('D');
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,8 +1,3 @@
-/* eslint-disable import/prefer-default-export */
-import camelcase from 'camelcase';
-
-export const eventToAction = event => `socket_${camelcase(event.replace('SOCKET', ''))}`;
-
 export const isFunction = obj => typeof obj === 'function';
 
 export const isSocketIo = obj => !!obj && isFunction(obj.on) && isFunction(obj.emit);
@@ -12,3 +7,9 @@ export const unwrapIfSingle = args => (
     ? args[0]
     : args
 );
+
+export const pipe = (...fns) => x =>
+  fns.reduce((v, f) => f(v), x);
+
+export const prefixWith = prefix => string =>
+  prefix + string;

--- a/src/utils/observer.js
+++ b/src/utils/observer.js
@@ -1,0 +1,6 @@
+import camelcase from 'camelcase';
+
+export const eventToMutationTransformer = event =>
+  event.toUpperCase();
+
+export const eventToActionTransformer = camelcase;

--- a/src/utils/vuex.js
+++ b/src/utils/vuex.js
@@ -1,0 +1,10 @@
+export const getRegisteredMutations = store =>
+  // eslint-disable-next-line no-underscore-dangle
+  Object.keys(store._mutations);
+
+export const getRegisteredActions = store =>
+  // eslint-disable-next-line no-underscore-dangle
+  Object.keys(store._actions);
+
+export const trimNamespace = namespaced =>
+  namespaced.split('/').pop();


### PR DESCRIPTION
- improves maintainability (`passToStore` is much easier to read)
- better separation of concerns
- prepare `actionPrefix` and `mutationPrefix` for moving to options
- prepare `eventTo{Action|Mutation}Transformer` for moving to options
- `passToStore` now accepts raw events (no `SOCKET_` shenanigans)
- slightly improve performance for stores with large amount of actions / mutations