### PR TITLE
ci: use `node:alpine` image instead of `circleci/node:latest`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:latest
+      - image: node:alpine
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images


### PR DESCRIPTION
Feel the difference:
- circleci/node:latest -> 650Mb
- node:alpine -> 25Mb