### PR TITLE
Fix TypeScript hinting for custom options

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -6,7 +6,7 @@ import { App } from "vue";
 import * as SocketIOClient from 'socket.io-client';
 
 type DefaultSocketHandlers = {
-  [key: string]: (this: App, ...args: any[]) => any
+  [key: string]: (...args: any[]) => any
 };
 
 import { ComponentCustomOptions } from 'vue';


### PR DESCRIPTION
TypeScript thinks "this" is referring to the App object.