### PR TITLE
Fix types definition for decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Check the example below:
 <!-- App.vue -->
 <script>
 import { Options, Vue } from 'vue-class-component';
-import { Socket } from 'vue-socket.io-extended'
+import Socket from 'vue-socket.io-extended/decorator';
 
 @Options({})
 export default class App extends Vue {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "import": "./dist/vue-socket.io-ext.esm.js",
       "default": "./dist/vue-socket.io-ext.min.js"
     },
-    "./decorator/": "./dist/vue-socket.io-ext.decorator.esm.js"
+    "./decorator": "./dist/vue-socket.io-ext.decorator.esm.js"
   },
   "scripts": {
     "test": "jest",
@@ -27,6 +27,11 @@
     "types/"
   ],
   "typings": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "decorator": ["types/decorator.d.ts"]
+    }
+  },
   "keywords": [
     "vuejs",
     "socket",

--- a/types/decorator.d.ts
+++ b/types/decorator.d.ts
@@ -1,0 +1,5 @@
+import { VueDecorator } from 'vue-class-component';
+
+declare const Socket: (eventName?: string) => VueDecorator;
+
+export default Socket;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,5 @@
 // @ts-ignore
 import { PluginInstallFunction } from 'vue';
-import { VueDecorator } from 'vue-class-component';
 import * as SocketIOClient from 'socket.io-client';
 // augment typings of Vue.js
 import "./vue"
@@ -23,4 +22,3 @@ declare class VueSocketIOExt {
 }
 
 export default VueSocketIOExt;
-export const Socket: (eventName?: string) => VueDecorator;


### PR DESCRIPTION
I noticed that the types definition for the decorator were not changed when the decorator was excluded from the index file. So I removed the export of Socket from index and moved it to another definition file.
With this article, I figured out how to provide the definition file for the submodule: https://dev.to/binjospookie/exports-in-package-json-1fl2

Before this, I was not able to use Socket with TypeScript. The Import `import Socket from 'vue-socket.io-extended/decorator';` was not working and IDE mentioned that there was no module found named `vue-socket.io-extended/decorator`. 
The change to package.json was needed because IDE would mention to use import `import Socket from 'vue-socket.io-extended/types/decorator';` which is working in IDE but not when compiling as the JS import is wrong.

https://github.com/probil/vue-socket.io-extended/issues/489#issuecomment-839978807